### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/vale-linter.yaml
+++ b/.github/workflows/vale-linter.yaml
@@ -1,4 +1,6 @@
 name: Vale Lint Checker
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Intugle/data-tools/security/code-scanning/4](https://github.com/Intugle/data-tools/security/code-scanning/4)

The best way to fix this issue is to explicitly specify a restrictive `permissions` block in the workflow YAML. For a linter job like this, which doesn't write to the repository, it's sufficient—and best—practice to set `permissions: contents: read` at either the workflow root or the job level. Since this workflow only contains one job, adding it at the workflow root is the simplest and most effective approach. This restricts the GITHUB_TOKEN to read-only access, minimizing the impact in case of compromise, and adheres to the principle of least privilege. The change should be made directly after the `name:` field and before the `on:` field (i.e., as the second block in the YAML file).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
