### PR TITLE
Fix: Remove hardcoded MODEL_VERSION in DI pipeline

### DIFF
--- a/src/intugle/core/pipeline/datatype_identification/pipeline.py
+++ b/src/intugle/core/pipeline/datatype_identification/pipeline.py
@@ -11,7 +11,7 @@ from .l1_model import L1Model
 log = logging.getLogger(__name__)
 
 
-MODEL_VERSION = "13052023"
+MODEL_VERSION = settings.DI_MODEL_VERSION
 
 
 class DataTypeIdentificationPipeline:


### PR DESCRIPTION
- Replaced the hard-coded model version with setting object. 
- Got familiarized with the codebase a bit