### PR TITLE
feat: Add support for Anthropic Claude in Streamlit app

### DIFF
--- a/src/intugle/streamlit_app/helper.py
+++ b/src/intugle/streamlit_app/helper.py
@@ -772,6 +772,12 @@ def llm_ready_check() -> tuple[bool, str]:
             return False, "Gemini key missing. Please set **GEMINI_API_KEY** (or GOOGLE_API_KEY) in the sidebar."
         return True, ""
 
+    if provider == "anthropic":
+        key = _get_secret_env("ANTHROPIC_API_KEY")  # type: ignore[name-defined]
+        if not key:
+            return False, "Anthropic key missing. Please set **ANTHROPIC_API_KEY** in the sidebar."
+        return True, ""
+
     return False, f"Unknown provider '{provider}'."
 
 

--- a/src/intugle/streamlit_app/main.py
+++ b/src/intugle/streamlit_app/main.py
@@ -1031,9 +1031,9 @@ with st.sidebar:
             model = st.selectbox(
                 "Model",
                 [
-                    "claude-sonnet-4-5-20250929",
-                    "claude-haiku-4-5-20250929",
-                    "claude-opus-4-1-20250514",
+                    "claude-sonnet-4-5",
+                    "claude-haiku-4-5",
+                    "claude-opus-4-1",
                 ],
                 index=0,
                 help="Claude Sonnet 4.5: Best balance of intelligence, speed, and cost\nClaude Haiku 4.5: Fastest with near-frontier intelligence\nClaude Opus 4.1: Exceptional for specialized reasoning",


### PR DESCRIPTION
## Description
  Add Anthropic Claude as a new LLM provider option in the Streamlit app, allowing users to use Claude models (Sonnet 4.5, Haiku 4.5, and Opus 4.1) for    
   semantic modeling tasks.

  ## Type of Change
  - [x] ✨ New feature (non-breaking change which adds functionality)

  ## Changes Made
  - Added `langchain_anthropic` import for Claude model integration
  - Updated LLM provider selection dropdown to include "anthropic" option
  - Added Anthropic-specific UI section with:
    - Model selection dropdown (claude-sonnet-4-5, claude-haiku-4-5, claude-opus-4-1)
    - API key input field with validation
    - Connection test using French-to-English translation
  - Added Anthropic provider validation in `helper.py` (`llm_ready_check()` function)
  - Used model aliases (without dates) for automatic updates to latest versions

  ## Testing
  ### Test Configuration
  - **Python Version**: 3.x
  - **OS**: Windows
  - **LLM Provider**: Anthropic Claude

  ### Test Cases
  - [x] Manual testing completed
  - [x] Tested with sample datasets (basketball players and teams CSV files)
  - [x] API connection test successful
  - [x] Model selection UI verified
  - [x] Provider validation working correctly

  ### Test Results
  - Successfully configured Anthropic API key
  - Connection test passed (French translation successful)
  - Semantic model creation works with Claude models
  - No breaking changes to existing providers (OpenAI, Azure OpenAI, Google Gemini)

  ## Screenshots/Examples
  N/A - UI changes visible in Streamlit sidebar under "LLM Settings"

  ## Checklist
  - [x] My code follows the code style of this project
  - [x] I have performed a self-review of my own code
  - [x] My changes generate no new warnings or linter errors
  - [x] New and existing unit tests pass locally with my changes
  - [x] Any dependent changes have been merged and published

  ## Documentation Updates
  - [ ] README.md updated (not required - self-explanatory UI)
  - [ ] Docstrings added/updated (not required)
  - [x] No documentation changes needed - feature is self-contained in UI

  ## Breaking Changes
  - [ ] This PR introduces breaking changes

  ## Performance Impact
  - [x] No significant performance impact

  ## Additional Context
  This addition enables users to leverage Anthropic's Claude models for:
  - Data profiling and glossary generation
  - Semantic link prediction between tables
  - Enhanced reasoning capabilities for complex data relationships

  The implementation follows the existing pattern used for other LLM providers (OpenAI, Azure OpenAI, Google Gemini).

  ## Deployment Notes
  Requires `langchain-anthropic` package (already present in dependencies).
  Users need to obtain an Anthropic API key from https://console.anthropic.com/