### PR TITLE
Fix Qdrant cloud indexing: Add keyword index for 'type' field during

### DIFF
--- a/src/intugle/core/semantic_search/crud.py
+++ b/src/intugle/core/semantic_search/crud.py
@@ -50,7 +50,15 @@ class SemanticSearchCRUD:
             }
             embeddings_configurations = {**embeddings_configurations, **config}
 
-        configuration = QdrantVectorConfiguration(vectors_config=embeddings_configurations)
+        # Payload schema with keyword index for "type" field required for filtering
+        payload_schema = {
+            "type": models.PayloadSchemaType.KEYWORD,
+        }
+
+        configuration = QdrantVectorConfiguration(
+            vectors_config=embeddings_configurations,
+            payload_schema=payload_schema
+        )
 
         return configuration
 

--- a/src/intugle/core/vector_store/qdrant.py
+++ b/src/intugle/core/vector_store/qdrant.py
@@ -21,6 +21,8 @@ class QdrantVectorConfiguration(BaseModel):
 
     sparse_vectors_config: Optional[Mapping[str, qdrant_types.SparseVectorParams]] = None
 
+    payload_schema: Optional[Mapping[str, models.PayloadSchemaType]] = None
+
 
 # Used for standardization
 


### PR DESCRIPTION
**Issue link:** https://github.com/Intugle/data-tools/issues/144

**_Description_**
Fixes "Index required but not found for 'type' field" error on cloud-hosted Qdrant instances by adding proper keyword indexing for the 'type' payload field during collection creation.

**Type of Change**
Bug fix (non-breaking change which fixes an issue)

**Related Issue(s)**
Fixes #[HELP WANTED] Bug: Qdrant semantic search fails due to missing index for "type" field

**Changes Made**
Added payload_schema parameter to QdrantVectorConfiguration for payload index support
Updated collection creation to include keyword index for 'type' field
Removed manual post-creation index creation (now handled at collection init)

**Testing**
Test Commands:
uv run pytest tests/semantic_search/ -v
uv run pytest tests/ -v --tb=short
All tests pass: 63 passed, 18 skipped

**Checklist**
-[x] My code follows the code style of this project
-[x] Unit tests pass locally
-[x] New and existing functionality works
-[x] No breaking changes

**Additional Context**
This resolves the Qdrant cloud filtering issue by ensuring collections are created with proper keyword indexes from the start.