### PR TITLE
fix(security): resolve uuid buffer bounds CVE via npm override

### DIFF
--- a/docsite/package-lock.json
+++ b/docsite/package-lock.json
@@ -18488,12 +18488,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/value-equal": {

--- a/docsite/package.json
+++ b/docsite/package.json
@@ -40,7 +40,8 @@
     "minimatch": "^3.1.4",
     "ajv": "^8.18.0",
     "qs": "^6.14.2",
-    "webpack": "^5.104.1"
+    "webpack": "^5.104.1",
+    "uuid": "^11.1.1"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Summary
Fixes npm audit alert for uuid missing buffer bounds check vulnerability (GHSA-w5hq-g745-h8pq, CVE-related).

## Changes
- Add `uuid ^11.1.1` override to docsite/package.json overrides section
- Update docsite/package-lock.json: uuid 8.3.2 → 11.1.1
- Resolves: "Missing buffer bounds check in v3/v5/v6 when buf is provided" (CWE-787, CWE-1285)

## Affected Package
- **uuid**: 8.3.2 → 11.1.1
- **Path**: docsite/ (npm dependencies)
- **Why**: Transitive dependency via `@docusaurus/core → webpack-dev-server → sockjs → uuid`

## Testing
- ✅ npm audit: uuid advisory cleared
- ✅ npm run typecheck: Passed
- ✅ npm run build: Success (generated static files)
- ✅ No breaking changes to docsite

## Notes
- The vulnerable uuid v8.3.2 was pulled in transitively through the Docusaurus build toolchain
- npm audit fix could not resolve this automatically (fixAvailable: false)
- Override in package.json ensures uuid is always ≥11.1.1 across the dependency tree
- One unrelated moderate vulnerability remains (js-yaml in gray-matter)
