### PR TITLE
Add public API exports to link_predictor module

### DIFF
--- a/src/intugle/link_predictor/__init__.py
+++ b/src/intugle/link_predictor/__init__.py
@@ -1,2 +1,24 @@
+"""
+Link Predictor Module
 
+This module provides functionality for predicting relationships between datasets
+based on column profiling, data type analysis, and LLM-based inference.
+"""
 
+from intugle.link_predictor.models import (
+    LinkPredictionResult,
+    PredictedLink,
+)
+from intugle.link_predictor.predictor import (
+    LinkPredictionSaver,
+    LinkPredictor,
+    NoLinksFoundError,
+)
+
+__all__ = [
+    "LinkPredictor",
+    "LinkPredictionSaver",
+    "PredictedLink",
+    "LinkPredictionResult",
+    "NoLinksFoundError",
+]

--- a/tests/link_predictor/test_public_api.py
+++ b/tests/link_predictor/test_public_api.py
@@ -1,0 +1,32 @@
+"""Tests for link_predictor public API exports in __init__.py."""
+
+
+def test_public_api_imports_from_package():
+    """Users can import main classes directly from intugle.link_predictor."""
+    from intugle.link_predictor import (
+        LinkPredictionResult,
+        LinkPredictionSaver,
+        LinkPredictor,
+        NoLinksFoundError,
+        PredictedLink,
+    )
+
+    assert LinkPredictor is not None
+    assert LinkPredictionSaver is not None
+    assert PredictedLink is not None
+    assert LinkPredictionResult is not None
+    assert NoLinksFoundError is not None
+
+
+def test_all_exports_match_public_api():
+    """__all__ should expose exactly the documented public API."""
+    import intugle.link_predictor as link_predictor
+
+    expected = {
+        "LinkPredictor",
+        "LinkPredictionSaver",
+        "PredictedLink",
+        "LinkPredictionResult",
+        "NoLinksFoundError",
+    }
+    assert set(link_predictor.__all__) == expected


### PR DESCRIPTION
## Summary

Adds public API exports to `src/intugle/link_predictor/__init__.py` so users can import the main link predictor classes directly from the package:

```python
from intugle.link_predictor import LinkPredictor, PredictedLink, LinkPredictionResult
```

instead of verbose submodule imports.

## Changes

- Add module docstring describing the link predictor package
- Export `LinkPredictor`, `LinkPredictionSaver`, and `NoLinksFoundError` from `predictor`
- Export `PredictedLink` and `LinkPredictionResult` from `models`
- Define `__all__` for an explicit public API
- Add regression tests in `tests/link_predictor/test_public_api.py`

## Testing

- `python -c "from intugle.link_predictor import LinkPredictor; print('OK')"` — passes
- `pytest tests/link_predictor/test_public_api.py` — 2/2 passed
- `ruff check src/intugle/link_predictor/__init__.py` — passes
- `pytest tests/link_predictor/` — 16/23 passed (7 integration tests require LLM/API credentials)

Fixes #127